### PR TITLE
Actually install the extra apt packages

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -49,8 +49,8 @@ jobs:
               - ros-dashing-ros-base
               - ros-eloquent-desktop
               - ros-eloquent-ros-base
-              - ros-foxy-desktop
-              - ros-foxy-ros-base
+              # - ros-foxy-desktop
+              # - ros-foxy-ros-base
               - ros-kinetic-desktop
               - ros-kinetic-ros-base
               - ros-melodic-desktop
@@ -81,10 +81,10 @@ jobs:
             base_image_tag: bionic
 
           # Foxy Fitzroy (May 2020 - May 2023+)
-          - extra_apt_packages: ros-foxy-desktop
-            base_image_tag: focal
-          - extra_apt_packages: ros-foxy-ros-base
-            base_image_tag: focal
+          # - extra_apt_packages: ros-foxy-desktop
+          #   base_image_tag: focal
+          # - extra_apt_packages: ros-foxy-ros-base
+          #   base_image_tag: focal
 
     name: "${{ matrix.base_image_name }}-${{ matrix.base_image_tag }}-${{ matrix.extra_apt_packages }}"
     # always use latest linux worker, as it should not have any impact

--- a/Dockerfile
+++ b/Dockerfile
@@ -14,16 +14,16 @@ ARG BASE_IMAGE_NAME
 # Base Linux distribution version (one of "bionic", "focal", "xenial")
 ARG BASE_IMAGE_TAG
 
+FROM "${BASE_IMAGE_NAME}:${BASE_IMAGE_TAG}"
+
+# Commit ID this image is based upon
+ARG VCS_REF
+
 # Additional APT packages to be installed
 #
 # This is used to build Docker images incorporating various ROS, or ROS 2
 # distributions. E.g. "ros-melodic-desktop ros-eloquent-desktop"
 ARG EXTRA_APT_PACKAGES
-
-# Commit ID this image is based upon
-ARG VCS_REF
-
-FROM "${BASE_IMAGE_NAME}:${BASE_IMAGE_TAG}"
 
 # See http://label-schema.org/rc1/ for label documentation
 LABEL org.label-schema.schema-version="1.0"
@@ -38,6 +38,6 @@ COPY setup-ros.sh /tmp/setup-ros.sh
 RUN /tmp/setup-ros.sh && rm -f /tmp/setup-ros.sh
 ENV LANG en_US.UTF-8
 RUN for i in ${EXTRA_APT_PACKAGES}; do \
-        apt-get install --yes --no-recommends "$i"; \
+        apt-get install --yes --no-install-recommends "$i"; \
     done
 USER rosbuild


### PR DESCRIPTION
The Docker arguments that were specified before the FROM statement were always empty after the FROM statement. You can tell it's not working by the logs, and by the fact that the output images are the same size for `ros-base` vs `ros-desktop` https://hub.docker.com/repository/docker/rostooling/setup-ros-docker/tags?page=1