### PR TITLE
Enable Foxy builds, using the ros2-testing repos

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -30,6 +30,7 @@ jobs:
             BASE_IMAGE_NAME=${{ matrix.base_image_name }}
             BASE_IMAGE_TAG=${{ matrix.base_image_tag }}
             VCS_REF=${{ github.sha }}
+            ROS_DISTRO=''
         imageName: "setup-ros-docker-${{ matrix.base_image_name }}-${{ matrix.base_image_tag }}"
     # Publish the image to DockerHub too
     - run: docker login -u "${{ secrets.DOCKER_USERNAME }}" -p "${{ secrets.DOCKER_PASSWORD }}"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -31,6 +31,7 @@ jobs:
             BASE_IMAGE_TAG=${{ matrix.base_image_tag }}
             VCS_REF=${{ github.sha }}
             ROS_DISTRO=''
+            ROS_APT_REPO_URL='http://packages.ros.org/ros'
         imageName: "setup-ros-docker-${{ matrix.base_image_name }}-${{ matrix.base_image_tag }}"
     # Publish the image to DockerHub too
     - run: docker login -u "${{ secrets.DOCKER_USERNAME }}" -p "${{ secrets.DOCKER_PASSWORD }}"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -30,8 +30,7 @@ jobs:
             BASE_IMAGE_NAME=${{ matrix.base_image_name }}
             BASE_IMAGE_TAG=${{ matrix.base_image_tag }}
             VCS_REF=${{ github.sha }}
-            ROS_DISTRO=
-            "ROS_APT_REPO_URL=http://packages.ros.org/ros&#x20;http://packages.ros.org/ros2"
+            ROS_APT_REPO_URLS=http://packages.ros.org/ros,http://packages.ros.org/ros2
         imageName: "setup-ros-docker-${{ matrix.base_image_name }}-${{ matrix.base_image_tag }}"
     # Publish the image to DockerHub too
     - run: docker login -u "${{ secrets.DOCKER_USERNAME }}" -p "${{ secrets.DOCKER_PASSWORD }}"
@@ -127,7 +126,7 @@ jobs:
             EXTRA_APT_PACKAGES=ros-${{ matrix.ros_distro }}-${{ matrix.ros_variant }}
             VCS_REF=${{ github.sha }}
             ROS_DISTRO=${{ matrix.ros_distro }}
-            ROS_APT_REPO_URL=${{ matrix.ros_repo_url }}
+            ROS_APT_REPO_URLS=${{ matrix.ros_repo_url }}
         imageName: "setup-ros-docker-${{ matrix.output_image_tag }}"
     # Publish the image to DockerHub too
     - run: docker login -u "${{ secrets.DOCKER_USERNAME }}" -p "${{ secrets.DOCKER_PASSWORD }}"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -45,6 +45,7 @@ jobs:
       matrix:
           base_image_name: [ubuntu]
           ros_distro: [kinetic, melodic, dashing, eloquent, foxy]
+          ros_variant: [desktop, ros-base]
           include:
 
           # Kinetic Kame (May 2016 - May 2021)

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -44,49 +44,60 @@ jobs:
       fail-fast: false
       matrix:
           base_image_name: [ubuntu]
-          extra_apt_packages:
-              - ros-dashing-desktop
-              - ros-dashing-ros-base
-              - ros-eloquent-desktop
-              - ros-eloquent-ros-base
-              # - ros-foxy-desktop
-              # - ros-foxy-ros-base
-              - ros-kinetic-desktop
-              - ros-kinetic-ros-base
-              - ros-melodic-desktop
-              - ros-melodic-ros-base
+          ros_distro: [kinetic, melodic, dashing, eloquent, foxy]
           include:
+
           # Kinetic Kame (May 2016 - May 2021)
-          - extra_apt_packages: ros-kinetic-desktop
+          - ros_distro: kinetic
             base_image_tag: xenial
-          - extra_apt_packages: ros-kinetic-ros-base
+            ros_variant: desktop
+            output_image_tag: ubuntu-xenial-ros-kinetic-desktop
+          - ros_distro: kinetic
             base_image_tag: xenial
+            ros_variant: ros-base
+            output_image_tag: ubuntu-xenial-ros-kinetic-ros-base
 
           # Melodic Morenia (May 2018 - May 2023)
-          - extra_apt_packages: ros-melodic-desktop
+          - ros_distro: melodic
             base_image_tag: bionic
-          - extra_apt_packages: ros-melodic-ros-base
+            ros_variant: desktop
+            output_image_tag: ubuntu-bionic-ros-melodic-desktop
+          - ros_distro: melodic
             base_image_tag: bionic
+            ros_variant: ros-base
+            output_image_tag: ubuntu-bionic-ros-melodic-ros-base
 
           # Dashing Diademata (May 2019 - May 2021)
-          - extra_apt_packages: ros-dashing-desktop
+          - ros_distro: dashing
             base_image_tag: bionic
-          - extra_apt_packages: ros-dashing-ros-base
+            ros_variant: desktop
+            output_image_tag: ubuntu-bionic-ros-dashing-desktop
+          - ros_distro: dashing
             base_image_tag: bionic
+            ros_variant: ros-base
+            output_image_tag: ubuntu-bionic-ros-dashing-ros-base
 
           # Eloquent Elusor (November 2019 - November 2020)
-          - extra_apt_packages: ros-eloquent-desktop
+          - ros_distro: eloquent
             base_image_tag: bionic
-          - extra_apt_packages: ros-eloquent-ros-base
+            ros_variant: desktop
+            output_image_tag: ubuntu-bionic-ros-eloquent-desktop
+          - ros_distro: eloquent
             base_image_tag: bionic
+            ros_variant: ros-base
+            output_image_tag: ubuntu-bionic-ros-eloquent-ros-base
 
           # Foxy Fitzroy (May 2020 - May 2023+)
-          # - extra_apt_packages: ros-foxy-desktop
-          #   base_image_tag: focal
-          # - extra_apt_packages: ros-foxy-ros-base
-          #   base_image_tag: focal
+          - ros_distro: foxy
+            base_image_tag: focal
+            ros_variant: desktop
+            output_image_tag: ubuntu-focal-ros-foxy-desktop
+          - ros_distro: foxy
+            base_image_tag: focal
+            ros_variant: ros-base
+            output_image_tag: ubuntu-focal-ros-foxy-ros-base
 
-    name: "${{ matrix.base_image_name }}-${{ matrix.base_image_tag }}-${{ matrix.extra_apt_packages }}"
+    name: "${{ matrix.output_image_tag }}"
     # always use latest linux worker, as it should not have any impact
     # when it comes to building docker images.
     runs-on: ubuntu-latest
@@ -100,15 +111,16 @@ jobs:
         buildArg: |
             BASE_IMAGE_NAME=${{ matrix.base_image_name }}
             BASE_IMAGE_TAG=${{ matrix.base_image_tag }}
-            EXTRA_APT_PACKAGES=${{ matrix.extra_apt_packages }}
+            EXTRA_APT_PACKAGES=ros-${{ matrix.ros_distro }}-${{ matrix.ros_variant }}
             VCS_REF=${{ github.sha }}
-        imageName: "setup-ros-docker-${{ matrix.base_image_name }}-${{ matrix.base_image_tag }}-${{ matrix.extra_apt_packages }}"
+            ROS_DISTRO=${{ matrix.ros_distro }}
+        imageName: "setup-ros-docker-${{ matrix.output_image_tag }}"
     # Publish the image to DockerHub too
     - run: docker login -u "${{ secrets.DOCKER_USERNAME }}" -p "${{ secrets.DOCKER_PASSWORD }}"
     - run: docker images
-    - run: "docker tag docker.pkg.github.com/ros-tooling/setup-ros-docker/setup-ros-docker-${{ matrix.base_image_name }}-${{ matrix.base_image_tag }}-${{ matrix.extra_apt_packages }}:master rostooling/setup-ros-docker:${{ matrix.base_image_name }}-${{ matrix.base_image_tag }}-${{ matrix.extra_apt_packages }}-latest"
+    - run: "docker tag docker.pkg.github.com/ros-tooling/setup-ros-docker/setup-ros-docker-${{ matrix.output_image_tag }}:master rostooling/setup-ros-docker:${{ matrix.output_image_tag }}-latest"
       if: github.event_name != 'pull_request'
-    - run: "docker push rostooling/setup-ros-docker:${{ matrix.base_image_name }}-${{ matrix.base_image_tag }}-${{ matrix.extra_apt_packages}}-latest"
+    - run: "docker push rostooling/setup-ros-docker:${{ matrix.output_image_tag }}-latest"
       if: github.event_name != 'pull_request'
 
   log_workflow_status_to_cloudwatch:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -30,8 +30,8 @@ jobs:
             BASE_IMAGE_NAME=${{ matrix.base_image_name }}
             BASE_IMAGE_TAG=${{ matrix.base_image_tag }}
             VCS_REF=${{ github.sha }}
-            ROS_DISTRO=''
-            ROS_APT_REPO_URL='http://packages.ros.org/ros'
+            ROS_DISTRO=""
+            ROS_APT_REPO_URL="http://packages.ros.org/ros http://packages.ros.org/ros2"
         imageName: "setup-ros-docker-${{ matrix.base_image_name }}-${{ matrix.base_image_tag }}"
     # Publish the image to DockerHub too
     - run: docker login -u "${{ secrets.DOCKER_USERNAME }}" -p "${{ secrets.DOCKER_PASSWORD }}"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -93,11 +93,13 @@ jobs:
           - ros_distro: foxy
             base_image_tag: focal
             ros_variant: desktop
-            output_image_tag: ubuntu-focal-ros-foxy-desktop
+            ros_repo_suffix: -testing
+            output_image_tag: ubuntu-focal-ros-foxy-desktop-testing
           - ros_distro: foxy
             base_image_tag: focal
             ros_variant: ros-base
-            output_image_tag: ubuntu-focal-ros-foxy-ros-base
+            ros_repo_suffix: -testing
+            output_image_tag: ubuntu-focal-ros-foxy-ros-base-testing
 
     name: "${{ matrix.output_image_tag }}"
     # always use latest linux worker, as it should not have any impact
@@ -116,6 +118,7 @@ jobs:
             EXTRA_APT_PACKAGES=ros-${{ matrix.ros_distro }}-${{ matrix.ros_variant }}
             VCS_REF=${{ github.sha }}
             ROS_DISTRO=${{ matrix.ros_distro }}
+            ROS_REPO_SUFFIX=${{ matrix.ros_repo_suffix }}
         imageName: "setup-ros-docker-${{ matrix.output_image_tag }}"
     # Publish the image to DockerHub too
     - run: docker login -u "${{ secrets.DOCKER_USERNAME }}" -p "${{ secrets.DOCKER_PASSWORD }}"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -53,52 +53,60 @@ jobs:
           - ros_distro: kinetic
             base_image_tag: xenial
             ros_variant: desktop
+            ros_repo_url: http://packages.ros.org/ros
             output_image_tag: ubuntu-xenial-ros-kinetic-desktop
           - ros_distro: kinetic
             base_image_tag: xenial
             ros_variant: ros-base
+            ros_repo_url: http://packages.ros.org/ros
             output_image_tag: ubuntu-xenial-ros-kinetic-ros-base
 
           # Melodic Morenia (May 2018 - May 2023)
           - ros_distro: melodic
             base_image_tag: bionic
             ros_variant: desktop
+            ros_repo_url: http://packages.ros.org/ros
             output_image_tag: ubuntu-bionic-ros-melodic-desktop
           - ros_distro: melodic
             base_image_tag: bionic
             ros_variant: ros-base
+            ros_repo_url: http://packages.ros.org/ros
             output_image_tag: ubuntu-bionic-ros-melodic-ros-base
 
           # Dashing Diademata (May 2019 - May 2021)
           - ros_distro: dashing
             base_image_tag: bionic
             ros_variant: desktop
+            ros_repo_url: http://packages.ros.org/ros2
             output_image_tag: ubuntu-bionic-ros-dashing-desktop
           - ros_distro: dashing
             base_image_tag: bionic
             ros_variant: ros-base
+            ros_repo_url: http://packages.ros.org/ros2
             output_image_tag: ubuntu-bionic-ros-dashing-ros-base
 
           # Eloquent Elusor (November 2019 - November 2020)
           - ros_distro: eloquent
             base_image_tag: bionic
             ros_variant: desktop
+            ros_repo_url: http://packages.ros.org/ros2
             output_image_tag: ubuntu-bionic-ros-eloquent-desktop
           - ros_distro: eloquent
             base_image_tag: bionic
             ros_variant: ros-base
+            ros_repo_url: http://packages.ros.org/ros2
             output_image_tag: ubuntu-bionic-ros-eloquent-ros-base
 
           # Foxy Fitzroy (May 2020 - May 2023+)
           - ros_distro: foxy
             base_image_tag: focal
             ros_variant: desktop
-            ros_repo_suffix: -testing
+            ros_repo_url: http://packages.ros.org/ros2-testing
             output_image_tag: ubuntu-focal-ros-foxy-desktop-testing
           - ros_distro: foxy
             base_image_tag: focal
             ros_variant: ros-base
-            ros_repo_suffix: -testing
+            ros_repo_url: http://packages.ros.org/ros2-testing
             output_image_tag: ubuntu-focal-ros-foxy-ros-base-testing
 
     name: "${{ matrix.output_image_tag }}"
@@ -118,7 +126,7 @@ jobs:
             EXTRA_APT_PACKAGES=ros-${{ matrix.ros_distro }}-${{ matrix.ros_variant }}
             VCS_REF=${{ github.sha }}
             ROS_DISTRO=${{ matrix.ros_distro }}
-            ROS_REPO_SUFFIX=${{ matrix.ros_repo_suffix }}
+            ROS_APT_REPO_URL=${{ matrix.ros_repo_url }}
         imageName: "setup-ros-docker-${{ matrix.output_image_tag }}"
     # Publish the image to DockerHub too
     - run: docker login -u "${{ secrets.DOCKER_USERNAME }}" -p "${{ secrets.DOCKER_PASSWORD }}"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -30,8 +30,8 @@ jobs:
             BASE_IMAGE_NAME=${{ matrix.base_image_name }}
             BASE_IMAGE_TAG=${{ matrix.base_image_tag }}
             VCS_REF=${{ github.sha }}
-            ROS_DISTRO=""
-            ROS_APT_REPO_URL="http://packages.ros.org/ros http://packages.ros.org/ros2"
+            ROS_DISTRO=
+            "ROS_APT_REPO_URL=http://packages.ros.org/ros&#x20;http://packages.ros.org/ros2"
         imageName: "setup-ros-docker-${{ matrix.base_image_name }}-${{ matrix.base_image_tag }}"
     # Publish the image to DockerHub too
     - run: docker login -u "${{ secrets.DOCKER_USERNAME }}" -p "${{ secrets.DOCKER_PASSWORD }}"

--- a/Dockerfile
+++ b/Dockerfile
@@ -22,6 +22,9 @@ ARG VCS_REF
 # The ROS distribution being targeted by this image
 ARG ROS_DISTRO
 
+# The ROS repository that should be used (for example, release or testing)
+ARG ROS_REPO_SUFFIX
+
 # Additional APT packages to be installed
 #
 # This is used to build Docker images incorporating various ROS, or ROS 2
@@ -38,7 +41,7 @@ LABEL org.label-schema.vcs-ref="${VCS_REF}"
 LABEL org.label-schema.vendor="ROS Tooling Working Group"
 
 COPY setup-ros.sh /tmp/setup-ros.sh
-RUN /tmp/setup-ros.sh && rm -f /tmp/setup-ros.sh
+RUN /tmp/setup-ros.sh "${ROS_REPO_SUFFIX}" && rm -f /tmp/setup-ros.sh
 ENV LANG en_US.UTF-8
 RUN for i in ${EXTRA_APT_PACKAGES}; do \
         apt-get install --yes --no-install-recommends "$i"; \

--- a/Dockerfile
+++ b/Dockerfile
@@ -23,7 +23,7 @@ ARG VCS_REF
 ARG ROS_DISTRO
 
 # The ROS repository that should be used (for example, release or testing)
-ARG ROS_REPO_SUFFIX
+ARG ROS_APT_REPO_URL
 
 # Additional APT packages to be installed
 #
@@ -41,7 +41,7 @@ LABEL org.label-schema.vcs-ref="${VCS_REF}"
 LABEL org.label-schema.vendor="ROS Tooling Working Group"
 
 COPY setup-ros.sh /tmp/setup-ros.sh
-RUN /tmp/setup-ros.sh "${ROS_REPO_SUFFIX}" && rm -f /tmp/setup-ros.sh
+RUN /tmp/setup-ros.sh "${ROS_APT_REPO_URL}" && rm -f /tmp/setup-ros.sh
 ENV LANG en_US.UTF-8
 RUN for i in ${EXTRA_APT_PACKAGES}; do \
         apt-get install --yes --no-install-recommends "$i"; \

--- a/Dockerfile
+++ b/Dockerfile
@@ -23,7 +23,7 @@ ARG VCS_REF
 ARG ROS_DISTRO
 
 # The ROS repository that should be used (for example, release or testing)
-ARG ROS_APT_REPO_URL
+ARG ROS_APT_REPO_URLS
 
 # Additional APT packages to be installed
 #
@@ -41,7 +41,7 @@ LABEL org.label-schema.vcs-ref="${VCS_REF}"
 LABEL org.label-schema.vendor="ROS Tooling Working Group"
 
 COPY setup-ros.sh /tmp/setup-ros.sh
-RUN /tmp/setup-ros.sh "${ROS_APT_REPO_URL}" && rm -f /tmp/setup-ros.sh
+RUN /tmp/setup-ros.sh "${ROS_APT_REPO_URLS}" && rm -f /tmp/setup-ros.sh
 ENV LANG en_US.UTF-8
 RUN for i in ${EXTRA_APT_PACKAGES}; do \
         apt-get install --yes --no-install-recommends "$i"; \

--- a/Dockerfile
+++ b/Dockerfile
@@ -19,6 +19,9 @@ FROM "${BASE_IMAGE_NAME}:${BASE_IMAGE_TAG}"
 # Commit ID this image is based upon
 ARG VCS_REF
 
+# The ROS distribution being targeted by this image
+ARG ROS_DISTRO
+
 # Additional APT packages to be installed
 #
 # This is used to build Docker images incorporating various ROS, or ROS 2

--- a/setup-ros.sh
+++ b/setup-ros.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 set -euxo pipefail
 
-readonly ROS_APT_HTTP_REPO_URL=$1
+readonly ROS_APT_HTTP_REPO_URLS=$1
 
 apt-get update
 apt-get install --no-install-recommends --quiet --yes sudo
@@ -27,8 +27,9 @@ apt-get install --no-install-recommends --quiet --yes tzdata
 apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 \
     --recv-keys C1CF6E31E6BADE8868B172B4F42ED6FBAB17C654
 
-echo "deb ${ROS_APT_HTTP_REPO_URL}/ubuntu $(lsb_release -sc) main" \
-    > /etc/apt/sources.list.d/ros-latest.list
+for URL in ${ROS_APT_HTTP_REPO_URLS}; do
+    echo "deb ${URL}/ubuntu $(lsb_release -sc) main" >> /etc/apt/sources.list.d/ros-latest.list
+done
 
 apt-get update
 

--- a/setup-ros.sh
+++ b/setup-ros.sh
@@ -1,6 +1,8 @@
 #!/bin/bash
 set -euxo pipefail
 
+ROS_REPO_SUFFIX=$1
+
 apt-get update
 apt-get install --no-install-recommends --quiet --yes sudo
 
@@ -25,16 +27,9 @@ apt-get install --no-install-recommends --quiet --yes tzdata
 apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 \
     --recv-keys C1CF6E31E6BADE8868B172B4F42ED6FBAB17C654
 
-echo "deb http://packages.ros.org/ros/ubuntu $(lsb_release -sc) main" \
+echo "deb http://packages.ros.org/ros${ROS_REPO_SUFFIX}/ubuntu $(lsb_release -sc) main" \
     > /etc/apt/sources.list.d/ros-latest.list
-# Add in ros2-testing to find the Foxy beta
-if [[ "$ROS_DISTRO" == "foxy" ]]; then
-	ros2_apt_source="ros2-testing"
-else
-	ros2_apt_source="ros2"
-fi
-
-echo "deb http://packages.ros.org/${ros2_apt_source}/ubuntu $(lsb_release -sc) main" \
+echo "deb http://packages.ros.org/ros2${ROS_REPO_SUFFIX}/ubuntu $(lsb_release -sc) main" \
 	> /etc/apt/sources.list.d/ros2-latest.list
 
 apt-get update

--- a/setup-ros.sh
+++ b/setup-ros.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 set -euxo pipefail
 
-ROS_REPO_SUFFIX=$1
+readonly ROS_APT_HTTP_REPO_URL=$1
 
 apt-get update
 apt-get install --no-install-recommends --quiet --yes sudo
@@ -27,17 +27,15 @@ apt-get install --no-install-recommends --quiet --yes tzdata
 apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 \
     --recv-keys C1CF6E31E6BADE8868B172B4F42ED6FBAB17C654
 
-echo "deb http://packages.ros.org/ros${ROS_REPO_SUFFIX}/ubuntu $(lsb_release -sc) main" \
+echo "deb ${ROS_APT_HTTP_REPO_URL}/ubuntu $(lsb_release -sc) main" \
     > /etc/apt/sources.list.d/ros-latest.list
-echo "deb http://packages.ros.org/ros2${ROS_REPO_SUFFIX}/ubuntu $(lsb_release -sc) main" \
-	> /etc/apt/sources.list.d/ros2-latest.list
 
 apt-get update
 
 DEBIAN_FRONTEND=noninteractive \
 RTI_NC_LICENSE_ACCEPTED=yes \
 apt-get install --no-install-recommends --quiet --yes \
-  build-essential \
+	build-essential \
 	clang \
 	cmake \
 	git \

--- a/setup-ros.sh
+++ b/setup-ros.sh
@@ -27,7 +27,7 @@ apt-get install --no-install-recommends --quiet --yes tzdata
 apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 \
     --recv-keys C1CF6E31E6BADE8868B172B4F42ED6FBAB17C654
 
-for URL in ${ROS_APT_HTTP_REPO_URLS}; do
+for URL in ${ROS_APT_HTTP_REPO_URLS//,/ }; do
     echo "deb ${URL}/ubuntu $(lsb_release -sc) main" >> /etc/apt/sources.list.d/ros-latest.list
 done
 

--- a/setup-ros.sh
+++ b/setup-ros.sh
@@ -27,15 +27,22 @@ apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 \
 
 echo "deb http://packages.ros.org/ros/ubuntu $(lsb_release -sc) main" \
     > /etc/apt/sources.list.d/ros-latest.list
-echo "deb http://packages.ros.org/ros2/ubuntu $(lsb_release -sc) main" \
-    > /etc/apt/sources.list.d/ros2-latest.list
+# Add in ros2-testing to find the Foxy beta
+if [[ "$ROS_DISTRO" == "foxy" ]]; then
+	ros2_apt_source="ros2-testing"
+else
+	ros2_apt_source="ros2"
+fi
+
+echo "deb http://packages.ros.org/${ros2_apt_source}/ubuntu $(lsb_release -sc) main" \
+	> /etc/apt/sources.list.d/ros2-latest.list
 
 apt-get update
 
 DEBIAN_FRONTEND=noninteractive \
 RTI_NC_LICENSE_ACCEPTED=yes \
 apt-get install --no-install-recommends --quiet --yes \
-    build-essential \
+  build-essential \
 	clang \
 	cmake \
 	git \
@@ -46,7 +53,6 @@ apt-get install --no-install-recommends --quiet --yes \
 	libssl-dev \
 	libtinyxml2-dev \
 	python3-dev \
-	python3-lark-parser \
 	python3-pip \
 	python3-rosdep \
 	python3-vcstool \


### PR DESCRIPTION
Clarify the build matrix for images, and enable Foxy (with its ros2-testing apt repo)

I think this probably needs an integration test before merging.

Signed-off-by: Emerson Knapp <eknapp@amazon.com>