### PR TITLE
Create home directory for user

### DIFF
--- a/setup-ros.sh
+++ b/setup-ros.sh
@@ -5,7 +5,7 @@ apt-get update
 apt-get install --no-install-recommends --quiet --yes sudo
 
 groupadd -r rosbuild
-useradd --no-log-init -r -g rosbuild rosbuild
+useradd --no-log-init --create-home -r -g rosbuild rosbuild
 echo "rosbuild ALL=(ALL) NOPASSWD: ALL" >> /etc/sudoers
 
 echo 'Etc/UTC' > /etc/timezone


### PR DESCRIPTION
Currently, the `rosbuild` user doesn't have its own home directory. A home directory is needed for many things to work.

(The CI is currently working because GitHub actions remap $HOME to `/github/home/`.)