### PR TITLE
Install catkin_pkg over the top of the ros installation

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -40,4 +40,6 @@ ENV LANG en_US.UTF-8
 RUN for i in ${EXTRA_APT_PACKAGES}; do \
         apt-get install --yes --no-install-recommends "$i"; \
     done
+# ROS 1 installations clobber this - it doesn't affect ROS 2
+RUN pip3 install -U catkin_pkg
 USER rosbuild


### PR DESCRIPTION
Now that these base images are actually installing the ROS 1 variants, we've discovered that they clobber the `catkin_pkg` installation. The only good solution we have is to install again over the top. The `python3-catkin-pkg` install is incompatible with the ROS 1 apt packages, so it can't coexist, but the pip version enables running colcon without issue.

Signed-off-by: Emerson Knapp <emerson.b.knapp@gmail.com>