### PR TITLE
Install python-rosdep for ROS1 images

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -30,6 +30,7 @@ jobs:
             BASE_IMAGE_NAME=${{ matrix.base_image_name }}
             BASE_IMAGE_TAG=${{ matrix.base_image_tag }}
             VCS_REF=${{ github.sha }}
+            ROS_DISTRO=none
             ROS_APT_REPO_URLS=http://packages.ros.org/ros,http://packages.ros.org/ros2
         imageName: "setup-ros-docker-${{ matrix.base_image_name }}-${{ matrix.base_image_tag }}"
     # Publish the image to DockerHub too
@@ -54,13 +55,11 @@ jobs:
             base_image_tag: xenial
             ros_variant: desktop
             ros_repo_url: http://packages.ros.org/ros
-            extra_apt_packages: python-rosdep
             output_image_tag: ubuntu-xenial-ros-kinetic-desktop
           - ros_distro: kinetic
             base_image_tag: xenial
             ros_variant: ros-base
             ros_repo_url: http://packages.ros.org/ros
-            extra_apt_packages: python-rosdep
             output_image_tag: ubuntu-xenial-ros-kinetic-ros-base
 
           # Melodic Morenia (May 2018 - May 2023)
@@ -68,13 +67,11 @@ jobs:
             base_image_tag: bionic
             ros_variant: desktop
             ros_repo_url: http://packages.ros.org/ros
-            extra_apt_packages: python-rosdep
             output_image_tag: ubuntu-bionic-ros-melodic-desktop
           - ros_distro: melodic
             base_image_tag: bionic
             ros_variant: ros-base
             ros_repo_url: http://packages.ros.org/ros
-            extra_apt_packages: python-rosdep
             output_image_tag: ubuntu-bionic-ros-melodic-ros-base
 
           # Dashing Diademata (May 2019 - May 2021)
@@ -127,7 +124,7 @@ jobs:
         buildArg: |
             BASE_IMAGE_NAME=${{ matrix.base_image_name }}
             BASE_IMAGE_TAG=${{ matrix.base_image_tag }}
-            EXTRA_APT_PACKAGES=ros-${{ matrix.ros_distro }}-${{ matrix.ros_variant }},${{ matrix.extra_apt_packages }}
+            EXTRA_APT_PACKAGES=ros-${{ matrix.ros_distro }}-${{ matrix.ros_variant }}
             VCS_REF=${{ github.sha }}
             ROS_DISTRO=${{ matrix.ros_distro }}
             ROS_APT_REPO_URLS=${{ matrix.ros_repo_url }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -54,11 +54,13 @@ jobs:
             base_image_tag: xenial
             ros_variant: desktop
             ros_repo_url: http://packages.ros.org/ros
+            extra_apt_packages: python-rosdep
             output_image_tag: ubuntu-xenial-ros-kinetic-desktop
           - ros_distro: kinetic
             base_image_tag: xenial
             ros_variant: ros-base
             ros_repo_url: http://packages.ros.org/ros
+            extra_apt_packages: python-rosdep
             output_image_tag: ubuntu-xenial-ros-kinetic-ros-base
 
           # Melodic Morenia (May 2018 - May 2023)
@@ -66,11 +68,13 @@ jobs:
             base_image_tag: bionic
             ros_variant: desktop
             ros_repo_url: http://packages.ros.org/ros
+            extra_apt_packages: python-rosdep
             output_image_tag: ubuntu-bionic-ros-melodic-desktop
           - ros_distro: melodic
             base_image_tag: bionic
             ros_variant: ros-base
             ros_repo_url: http://packages.ros.org/ros
+            extra_apt_packages: python-rosdep
             output_image_tag: ubuntu-bionic-ros-melodic-ros-base
 
           # Dashing Diademata (May 2019 - May 2021)
@@ -123,7 +127,7 @@ jobs:
         buildArg: |
             BASE_IMAGE_NAME=${{ matrix.base_image_name }}
             BASE_IMAGE_TAG=${{ matrix.base_image_tag }}
-            EXTRA_APT_PACKAGES=ros-${{ matrix.ros_distro }}-${{ matrix.ros_variant }}
+            EXTRA_APT_PACKAGES=ros-${{ matrix.ros_distro }}-${{ matrix.ros_variant }},${{ matrx.extra_apt_packages }}
             VCS_REF=${{ github.sha }}
             ROS_DISTRO=${{ matrix.ros_distro }}
             ROS_APT_REPO_URLS=${{ matrix.ros_repo_url }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -127,7 +127,7 @@ jobs:
         buildArg: |
             BASE_IMAGE_NAME=${{ matrix.base_image_name }}
             BASE_IMAGE_TAG=${{ matrix.base_image_tag }}
-            EXTRA_APT_PACKAGES=ros-${{ matrix.ros_distro }}-${{ matrix.ros_variant }},${{ matrx.extra_apt_packages }}
+            EXTRA_APT_PACKAGES=ros-${{ matrix.ros_distro }}-${{ matrix.ros_variant }},${{ matrix.extra_apt_packages }}
             VCS_REF=${{ github.sha }}
             ROS_DISTRO=${{ matrix.ros_distro }}
             ROS_APT_REPO_URLS=${{ matrix.ros_repo_url }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -43,7 +43,7 @@ LABEL org.label-schema.vendor="ROS Tooling Working Group"
 COPY setup-ros.sh /tmp/setup-ros.sh
 RUN /tmp/setup-ros.sh "${ROS_APT_REPO_URLS}" && rm -f /tmp/setup-ros.sh
 ENV LANG en_US.UTF-8
-RUN for i in ${EXTRA_APT_PACKAGES}; do \
+RUN for i in ${EXTRA_APT_PACKAGES//,/ }; do \
         apt-get install --yes --no-install-recommends "$i"; \
     done
 # ROS 1 installations clobber this - it doesn't affect ROS 2

--- a/Dockerfile
+++ b/Dockerfile
@@ -43,7 +43,7 @@ LABEL org.label-schema.vendor="ROS Tooling Working Group"
 COPY setup-ros.sh /tmp/setup-ros.sh
 RUN /tmp/setup-ros.sh "${ROS_APT_REPO_URLS}" && rm -f /tmp/setup-ros.sh
 ENV LANG en_US.UTF-8
-RUN for i in ${EXTRA_APT_PACKAGES//,/ }; do \
+RUN for i in $(echo ${EXTRA_APT_PACKAGES} | tr ',' ' '); do \
         apt-get install --yes --no-install-recommends "$i"; \
     done
 # ROS 1 installations clobber this - it doesn't affect ROS 2

--- a/Dockerfile
+++ b/Dockerfile
@@ -41,7 +41,7 @@ LABEL org.label-schema.vcs-ref="${VCS_REF}"
 LABEL org.label-schema.vendor="ROS Tooling Working Group"
 
 COPY setup-ros.sh /tmp/setup-ros.sh
-RUN /tmp/setup-ros.sh "${ROS_APT_REPO_URLS}" && rm -f /tmp/setup-ros.sh
+RUN /tmp/setup-ros.sh "${ROS_DISTRO}" "${ROS_APT_REPO_URLS}" && rm -f /tmp/setup-ros.sh
 ENV LANG en_US.UTF-8
 RUN for i in $(echo ${EXTRA_APT_PACKAGES} | tr ',' ' '); do \
         apt-get install --yes --no-install-recommends "$i"; \

--- a/setup-ros.sh
+++ b/setup-ros.sh
@@ -1,7 +1,8 @@
 #!/bin/bash
 set -euxo pipefail
 
-readonly ROS_APT_HTTP_REPO_URLS=$1
+readonly ROS_DISTRO=$1
+readonly ROS_APT_HTTP_REPO_URLS=$2
 
 apt-get update
 apt-get install --no-install-recommends --quiet --yes sudo
@@ -31,6 +32,15 @@ for URL in ${ROS_APT_HTTP_REPO_URLS//,/ }; do
     echo "deb ${URL}/ubuntu $(lsb_release -sc) main" >> /etc/apt/sources.list.d/ros-latest.list
 done
 
+case ${ROS_DISTRO} in
+    "kinetic" | "melodic")
+        ROSDEP_APT_PACKAGE="python-rosdep"
+        ;;
+    *)
+        ROSDEP_APT_PACKAGE="python3-rosdep"
+        ;;
+esac
+
 apt-get update
 
 DEBIAN_FRONTEND=noninteractive \
@@ -48,9 +58,9 @@ apt-get install --no-install-recommends --quiet --yes \
 	libtinyxml2-dev \
 	python3-dev \
 	python3-pip \
-	python3-rosdep \
 	python3-vcstool \
 	python3-wheel \
+	${ROSDEP_APT_PACKAGE} \
 	rti-connext-dds-5.3.1 \
 	wget
 


### PR DESCRIPTION
Our base images install `python3-rosdep`, but this is apparently incompatible with the `ros-kinetic-ros-core`/`ros-melodic-ros-core` packages (by installing `ros-kinetic-ros-core`/`ros-melodic-ros-core`, `python3-rosdep` gets removed).

In order to have a usable `rosdep` in our ROS1 images, the `python-rosdep` APT package needs to be installed.