### PR TITLE
Only allow flake8<3.8 to be installed

### DIFF
--- a/setup-ros.sh
+++ b/setup-ros.sh
@@ -95,7 +95,7 @@ pip3 install --upgrade \
 	coverage \
 	cryptography \
 	empy \
-	flake8 \
+	"flake8<3.8" \
 	flake8-blind-except \
 	flake8-builtins \
 	flake8-class-newline \


### PR DESCRIPTION
Recent versions of flake8 are incompatible with ament_flake8.

This prevents incompatible from being installed until the issue is
fixed in all combinations of ROS / ROS 2 distributions this repository
supports.