### PR TITLE
Revert "Fix parameter name warning (#21)"

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -23,10 +23,10 @@ jobs:
     - name: checkout repository
       uses: actions/checkout@v2
     - name: publish image
-      uses: matootie/github-docker@v3.0.0
+      uses: matootie/github-docker@v2.2.2
       with:
         accessToken: ${{ secrets.github_token }}
-        buildArgs: |
+        buildArg: |
             BASE_IMAGE_NAME=${{ matrix.base_image_name }}
             BASE_IMAGE_TAG=${{ matrix.base_image_tag }}
             VCS_REF=${{ github.sha }}
@@ -118,10 +118,10 @@ jobs:
     - name: checkout repository
       uses: actions/checkout@v2
     - name: publish image
-      uses: matootie/github-docker@v3.0.0
+      uses: matootie/github-docker@v2.2.2
       with:
         accessToken: ${{ secrets.github_token }}
-        buildArgs: |
+        buildArg: |
             BASE_IMAGE_NAME=${{ matrix.base_image_name }}
             BASE_IMAGE_TAG=${{ matrix.base_image_tag }}
             EXTRA_APT_PACKAGES=ros-${{ matrix.ros_distro }}-${{ matrix.ros_variant }}


### PR DESCRIPTION
This reverts commit 64ff3b4a09bb274ac4e54e8d1edcd05c36ca56c2.

Unsure why there are CI failures so reverting all recent changes.