### PR TITLE
Run as root user

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -48,4 +48,3 @@ RUN for i in $(echo ${EXTRA_APT_PACKAGES} | tr ',' ' '); do \
     done
 # ROS 1 installations clobber this - it doesn't affect ROS 2
 RUN pip3 install -U catkin_pkg
-USER rosbuild

--- a/setup-ros.sh
+++ b/setup-ros.sh
@@ -7,10 +7,6 @@ readonly ROS_APT_HTTP_REPO_URLS=$2
 apt-get update
 apt-get install --no-install-recommends --quiet --yes sudo
 
-groupadd -r rosbuild
-useradd --no-log-init --create-home -r -g rosbuild rosbuild
-echo "rosbuild ALL=(ALL) NOPASSWD: ALL" >> /etc/sudoers
-
 echo 'Etc/UTC' > /etc/timezone
 
 apt-get update


### PR DESCRIPTION
Fixes #7 

According to the github action documentation, we should actually run all actions in containers as the root user - this is the recommended workflow. We originally chose non-root because its standard practice in other docker-based workflows, such as web applications.

From https://docs.github.com/en/free-pro-team@latest/actions/reference/specifications-for-github-hosted-runners
> Note: GitHub Actions must be run by the default Docker user (root). Ensure your Dockerfile does not set the USER instruction, otherwise you will not be able to access GITHUB_WORKSPACE

The above applies to also `GITHUB_ENV` and `GITHUB_PATH`, which are separate paths used by the `core.addPath` and `core.setEnv` commands from `@actions/core`. As of https://github.blog/changelog/2020-10-01-github-actions-deprecating-set-env-and-add-path-commands/ - anyone using these containers and those commands have permissions-based failures

