### PR TITLE
Pin importlib-metadata to v2

### DIFF
--- a/setup-ros.sh
+++ b/setup-ros.sh
@@ -111,6 +111,7 @@ pip3 install --upgrade \
 	flake8-import-order \
 	flake8-quotes \
 	ifcfg \
+	importlib-metadata==2.* \
 	lark-parser \
 	mock \
 	mypy \


### PR DESCRIPTION
For compatibility with Python2 and 3.5, the newest major version broke compatibility