### PR TITLE
Don't use testing repos anymore for Foxy since it is fully released and supported

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -102,13 +102,13 @@ jobs:
           - ros_distro: foxy
             base_image_tag: focal
             ros_variant: desktop
-            ros_repo_url: http://packages.ros.org/ros2-testing
-            output_image_tag: ubuntu-focal-ros-foxy-desktop-testing
+            ros_repo_url: http://packages.ros.org/ros2
+            output_image_tag: ubuntu-focal-ros-foxy-desktop
           - ros_distro: foxy
             base_image_tag: focal
             ros_variant: ros-base
-            ros_repo_url: http://packages.ros.org/ros2-testing
-            output_image_tag: ubuntu-focal-ros-foxy-ros-base-testing
+            ros_repo_url: http://packages.ros.org/ros2
+            output_image_tag: ubuntu-focal-ros-foxy-ros-base
 
     name: "${{ matrix.output_image_tag }}"
     # always use latest linux worker, as it should not have any impact


### PR DESCRIPTION
This fixes the build by using released version of Foxy. The only reason we used testing was to enable Foxy builds before it was initially released.

`ros-foxy-desktop` build is not currently working in `ros2-testing`, which is why it couldn't be found by the build. 
See https://build.ros2.org/job/Fbin_uF64__desktop__ubuntu_focal_amd64__binary/76/ for the failing build and 
http://packages.ros.org/ros2-testing/ubuntu/dists/focal/main/binary-amd64/Packages to see that `ros-foxy-desktop` is not present (but `ros-foxy-ros-base` is).

Note https://github.com/ros2/build_farmer/issues/275 opened for this separate issue