### PR TITLE
Only run 4 times a day

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -6,7 +6,7 @@ on:
       - master
   schedule:
     # Run the CI automatically every hour to look for flakyness.
-    - cron:  '0 * * * *'
+    - cron:  '0 */6 * * *'
 
 jobs:
   build_ubuntu_docker_image:


### PR DESCRIPTION
There is no real reason to build these images every hour, and we seem to be overloading some quotas when trying to upload - seeing frequent failures