### PR TITLE
Do an intermediate upgrade to pip 20 before trying any further, so that xenial can pass and avoid an incompatible version

### DIFF
--- a/setup-ros.sh
+++ b/setup-ros.sh
@@ -75,7 +75,11 @@ apt-get install --no-install-recommends --quiet --yes \
 apt-get install --no-install-recommends --quiet --yes libopensplice69 || true
 
 # Get the latest version of pip before installing dependencies,
-# the version from apt can be very out of date (v8.0 on xenial vs v20 as of this writing)
+# the version from apt can be very out of date (v8.0 on xenial)
+# The latest version of pip doesn't support Python3.5 as of v21,
+# but pip 8 doesn't understand the metadata that states this, so we must first
+# make an intermediate upgrade to pip 20, which does understand that information
+pip3 install --upgrade pip==20.*
 pip3 install --upgrade pip
 
 pip3 install --upgrade \

--- a/setup-ros.sh
+++ b/setup-ros.sh
@@ -79,8 +79,8 @@ apt-get install --no-install-recommends --quiet --yes libopensplice69 || true
 # The latest version of pip doesn't support Python3.5 as of v21,
 # but pip 8 doesn't understand the metadata that states this, so we must first
 # make an intermediate upgrade to pip 20, which does understand that information
-pip3 install --upgrade pip==20.*
-pip3 install --upgrade pip
+python3 -m pip install --upgrade pip==20.*
+python3 -m pip install --upgrade pip
 
 pip3 install --upgrade \
 	argcomplete \


### PR DESCRIPTION
This is expected to make the build go from red to green (the Xenial-based builds are failing)

See https://pip.pypa.io/en/stable/news/#id1 release notes for v21.0, which states that support for python 3.5 is dropped

See https://github.com/pypa/pip/issues/9515 for some more information