### PR TITLE
Remove kinetic due to EOL

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -5,7 +5,7 @@ on:
     branches:
       - master
   schedule:
-    # Run the CI automatically every hour to look for flakyness.
+    # Run the CI automatically every day to look for flakyness.
     - cron:  '0 0 * * *'
 
 jobs:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,7 +14,7 @@ jobs:
       fail-fast: false
       matrix:
           base_image_name: [ubuntu]
-          base_image_tag: [bionic, focal, xenial]
+          base_image_tag: [bionic, focal]
     name: "${{ matrix.base_image_name }}-${{ matrix.base_image_tag }}"
     # always use latest linux worker, as it should not have any impact
     # when it comes to building docker images.
@@ -46,21 +46,9 @@ jobs:
       fail-fast: false
       matrix:
           base_image_name: [ubuntu]
-          ros_distro: [kinetic, melodic, noetic, dashing, foxy, galactic, rolling]
+          ros_distro: [melodic, noetic, dashing, foxy, galactic, rolling]
           ros_variant: [desktop, ros-base]
           include:
-
-          # Kinetic Kame (May 2016 - May 2021)
-          - ros_distro: kinetic
-            base_image_tag: xenial
-            ros_variant: desktop
-            ros_repo_url: http://packages.ros.org/ros
-            output_image_tag: ubuntu-xenial-ros-kinetic-desktop
-          - ros_distro: kinetic
-            base_image_tag: xenial
-            ros_variant: ros-base
-            ros_repo_url: http://packages.ros.org/ros
-            output_image_tag: ubuntu-xenial-ros-kinetic-ros-base
 
           # Melodic Morenia (May 2018 - May 2023)
           - ros_distro: melodic

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -6,7 +6,7 @@ on:
       - master
   schedule:
     # Run the CI automatically every hour to look for flakyness.
-    - cron:  '0 * * * *'
+    - cron:  '0 0 * * *'
 
 jobs:
   build_ubuntu_docker_image:

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,6 @@
 # The script has been tested against:
 # - ubuntu:bionic
 # - ubuntu:focal
-# - ubuntu:xenial
 #
 # Do not pass directly "X:Y" to BASE_IMAGE_NAME, only pass the image name.
 # The version must be specified separately in BASE_IMAGE_TAG.
@@ -11,7 +10,7 @@
 # This script will not work with non-APT based Linux distributions.
 ARG BASE_IMAGE_NAME
 
-# Base Linux distribution version (one of "bionic", "focal", "xenial")
+# Base Linux distribution version (one of "bionic", "focal")
 ARG BASE_IMAGE_TAG
 
 FROM "${BASE_IMAGE_NAME}:${BASE_IMAGE_TAG}"


### PR DESCRIPTION
The images will still exist on Dockerhub, but as Kinetic is EOL, no changes will occur, so the old images may continue to be used successfully. We do not need to build them anymore.

Additionally, kinetic are the builds that are currently failing in [the hourly](https://github.com/ros-tooling/setup-ros-docker/actions/runs/1831979647) - so removing them should fix that build up pretty good.

I know it might be a bit overloaded but I also kicked the scheduled build back to daily, there is no good reason i can think of to run it every hour.