### PR TITLE
Fix typo in 'lsb_release' command name

### DIFF
--- a/setup-ros.sh
+++ b/setup-ros.sh
@@ -33,7 +33,7 @@ apt-get install --no-install-recommends --quiet --yes tzdata
 apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 \
     --recv-keys C1CF6E31E6BADE8868B172B4F42ED6FBAB17C654
 
-case $(lab_release -sc) in
+case $(lsb_release -sc) in
     "bionic")
         ROSDEP_APT_PACKAGE="python-rosdep"
         ;;
@@ -45,7 +45,7 @@ esac
 case ${ROS_DISTRO} in
     "none")
 		RTI_CONNEXT_DDS=""
-		case $(lab_release -sc) in
+		case $(lsb_release -sc) in
 			"bionic")
 				echo "deb http://packages.ros.org/ros/ubuntu $(lsb_release -sc) main" | tee /etc/apt/sources.list.d/ros-latest.list
 				;;


### PR DESCRIPTION
For example, this was causing melodic/bionic images to get `python3-rosdep` ([which is not the right package for Bionic; should be `python-rosdep`](https://wiki.ros.org/melodic/Installation/Ubuntu#Installation.2FUbuntu.2FBinariesBuildDependencies.Dependencies_for_building_packages)), and thus `rosdep` thus wasn't found.

Signed-off-by: Christophe Bedard <bedard.christophe@gmail.com>