### PR TITLE
Add Iron and remove Galactic

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -116,14 +116,6 @@ jobs:
 
           # Rolling Ridley (June 2020 - Ongoing)
           - ros_distro: rolling
-            base_image_tag: focal
-            ros_variant: desktop
-            output_image_tag: ubuntu-focal-ros-rolling-desktop
-          - ros_distro: rolling
-            base_image_tag: focal
-            ros_variant: ros-base
-            output_image_tag: ubuntu-focal-ros-rolling-ros-base
-          - ros_distro: rolling
             base_image_tag: jammy
             ros_variant: desktop
             output_image_tag: ubuntu-jammy-ros-rolling-desktop

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -60,7 +60,7 @@ jobs:
       fail-fast: false
       matrix:
           base_image_name: [ubuntu]
-          ros_distro: [melodic, noetic, foxy, galactic, humble, rolling]
+          ros_distro: [melodic, noetic, foxy, humble, iron, rolling]
           ros_variant: [desktop, ros-base]
           include:
 
@@ -94,16 +94,6 @@ jobs:
             ros_variant: ros-base
             output_image_tag: ubuntu-focal-ros-foxy-ros-base
 
-          # Galactic Geochelone (May 2021 - November 2022)
-          - ros_distro: galactic
-            base_image_tag: focal
-            ros_variant: desktop
-            output_image_tag: ubuntu-focal-ros-galactic-desktop
-          - ros_distro: galactic
-            base_image_tag: focal
-            ros_variant: ros-base
-            output_image_tag: ubuntu-focal-ros-galactic-ros-base
-
           # Humble Hawksbill (May 2022 - May 2027)
           - ros_distro: humble
             base_image_tag: jammy
@@ -113,6 +103,16 @@ jobs:
             base_image_tag: jammy
             ros_variant: ros-base
             output_image_tag: ubuntu-jammy-ros-humble-ros-base
+
+          # Iron Irwini (May 2023 - November 2024)
+          - ros_distro: iron
+            base_image_tag: jammy
+            ros_variant: desktop
+            output_image_tag: ubuntu-jammy-ros-iron-desktop
+          - ros_distro: iron
+            base_image_tag: jammy
+            ros_variant: ros-base
+            output_image_tag: ubuntu-jammy-ros-iron-ros-base
 
           # Rolling Ridley (June 2020 - Ongoing)
           - ros_distro: rolling


### PR DESCRIPTION
Iron all available now, can make base images for it

Galactic hit EOL in November so it is long past last sync. Melodic/Foxy are EOL this month but they still will have another sync, so we shouldn't remove yet.