### PR TITLE
Add a basic README and stop publishing to Docker Hub

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -20,40 +20,28 @@ jobs:
     # when it comes to building docker images.
     runs-on: ubuntu-latest
     steps:
-      -
-        name: Checkout repository
+      - name: Checkout repository
         uses: actions/checkout@v4
-      -
-        name: Set up docker buildx
+      - name: Set up docker buildx
         uses: docker/setup-buildx-action@v3
-      -
-        name: Login to DockerHub
-        uses: docker/login-action@v3
-        with:
-          username: ${{ secrets.DOCKER_USERNAME }}
-          password: ${{ secrets.DOCKER_PASSWORD }}
-      -
-        name: Login to Github Container Registry
+      - name: Login to Github Container Registry
         uses: docker/login-action@v3
         with:
           registry: ghcr.io
           username: ${{ github.repository_owner }}
           password: ${{ secrets.GITHUB_TOKEN }}
-      -
-        name: Build and push
+      - name: Build and push
         uses: docker/build-push-action@v5
         with:
           context: .
           platforms: linux/amd64,linux/arm64
           push: ${{ github.event_name != 'pull_request' }}
           build-args: |
-            BASE_IMAGE_NAME=${{ matrix.base_image_name }}
-            BASE_IMAGE_TAG=${{ matrix.base_image_tag }}
+            BASE_IMAGE=${{ matrix.base_image_name }}:${{ matrix.base_image_tag }}
             VCS_REF=${{ github.sha }}
             ROS_DISTRO=none
           tags: |
-            rostooling/setup-ros-docker:${{ matrix.base_image_name }}-${{ matrix.base_image_tag }}-latest
-            ghcr.io/ros-tooling/setup-ros-docker/setup-ros-docker-${{ matrix.base_image_name }}-${{ matrix.base_image_tag }}:master
+            ghcr.io/ros-tooling/setup-ros-docker/${{ matrix.base_image_name }}-${{ matrix.base_image_tag }}:latest
 
   build_ubuntu_docker_image_ros:
     strategy:
@@ -61,7 +49,7 @@ jobs:
       matrix:
           base_image_name: [ubuntu]
           ros_distro: [noetic, humble, iron, jazzy, rolling]
-          ros_variant: [desktop, ros-base]
+          ros_variant: [ros-core, ros-base, desktop]
           include:
 
           # Noetic Ninjemys (May 2020 - May 2025)
@@ -75,6 +63,11 @@ jobs:
             ros_variant: ros-base
             rmw_implementations:
             output_image_tag: ubuntu-focal-ros-noetic-ros-base
+          - ros_distro: noetic
+            base_image_tag: focal
+            ros_variant: ros-core
+            rmw_implementations:
+            output_image_tag: ubuntu-focal-ros-noetic-ros-core
 
           # Humble Hawksbill (May 2022 - May 2027)
           - ros_distro: humble
@@ -87,6 +80,11 @@ jobs:
             ros_variant: ros-base
             rmw_implementations: ros-humble-rmw-fastrtps-cpp,ros-humble-rmw-cyclonedds-cpp,ros-humble-rmw-connextdds
             output_image_tag: ubuntu-jammy-ros-humble-ros-base
+          - ros_distro: humble
+            base_image_tag: jammy
+            ros_variant: ros-core
+            rmw_implementations: ros-humble-rmw-fastrtps-cpp,ros-humble-rmw-cyclonedds-cpp,ros-humble-rmw-connextdds
+            output_image_tag: ubuntu-jammy-ros-humble-ros-core
 
           # Iron Irwini (May 2023 - November 2024)
           - ros_distro: iron
@@ -99,6 +97,11 @@ jobs:
             ros_variant: ros-base
             rmw_implementations: ros-iron-rmw-fastrtps-cpp,ros-iron-rmw-cyclonedds-cpp,ros-iron-rmw-connextdds
             output_image_tag: ubuntu-jammy-ros-iron-ros-base
+          - ros_distro: iron
+            base_image_tag: jammy
+            ros_variant: ros-core
+            rmw_implementations: ros-iron-rmw-fastrtps-cpp,ros-iron-rmw-cyclonedds-cpp,ros-iron-rmw-connextdds
+            output_image_tag: ubuntu-jammy-ros-iron-ros-core
 
           # Jazzy Jalisco (May 2024 - May 2029)
           - ros_distro: jazzy
@@ -129,38 +132,26 @@ jobs:
     # when it comes to building docker images.
     runs-on: ubuntu-latest
     steps:
-    -
-      name: Checkout repository
+    - name: Checkout repository
       uses: actions/checkout@v4
-    -
-      name: Set up docker buildx
+    - name: Set up docker buildx
       uses: docker/setup-buildx-action@v3
-    -
-      name: Login to DockerHub
-      uses: docker/login-action@v3
-      with:
-        username: ${{ secrets.DOCKER_USERNAME }}
-        password: ${{ secrets.DOCKER_PASSWORD }}
-    -
-      name: Login to Github Container Registry
+    - name: Login to Github Container Registry
       uses: docker/login-action@v3
       with:
         registry: ghcr.io
         username: ${{ github.repository_owner }}
         password: ${{ secrets.GITHUB_TOKEN }}
-    -
-      name: Build and push
+    - name: Build and push
       uses: docker/build-push-action@v5
       with:
         context: .
         platforms: linux/amd64,linux/arm64
         push: ${{ github.event_name != 'pull_request' }}
         build-args: |
-          BASE_IMAGE_NAME=${{ matrix.base_image_name }}
-          BASE_IMAGE_TAG=${{ matrix.base_image_tag }}
+          BASE_IMAGE=${{ matrix.base_image_name }}:${{ matrix.base_image_tag }}
           EXTRA_APT_PACKAGES=ros-${{ matrix.ros_distro }}-${{ matrix.ros_variant }},${{ matrix.rmw_implementations }}
           VCS_REF=${{ github.sha }}
           ROS_DISTRO=${{ matrix.ros_distro }}
         tags: |
-          rostooling/setup-ros-docker:${{ matrix.output_image_tag }}-latest
-          ghcr.io/ros-tooling/setup-ros-docker/setup-ros-docker-${{ matrix.output_image_tag }}:master
+          ghcr.io/ros-tooling/setup-ros-docker/${{ matrix.output_image_tag }}:latest

--- a/README.md
+++ b/README.md
@@ -1,3 +1,40 @@
 # setup-ros-docker
 
 [![Build Docker image](https://github.com/ros-tooling/setup-ros-docker/workflows/Build%20Docker%20image/badge.svg)](https://github.com/ros-tooling/setup-ros-docker/actions?query=workflow%3A%22Build+Docker+image%22)
+
+:warning: **IMPORTANT NOTE** : These images are no longer published to [Docker Hub](https://hub.docker.com/r/rostooling/setup-ros-docker) and are now only being pushed to [GHCR](https://github.com/orgs/ros-tooling/packages?repo_name=setup-ros-docker)
+
+This repository creates base docker images for ROS development and CI workflows.
+The purpose of these images is to provide a ready-to-use base development environment for building ROS projects.
+
+The types of images created are:
+* OS Base: has ROS APT repositories setup, and installed development tools to build ROS projects from source. Installs _no_ ROS packages
+* [`ros-core`](https://index.ros.org/p/ros_core/github-ros2-variants/): Built on OS Base, contains the `ros-core` variant preinstalled
+* [`ros-base`](https://index.ros.org/p/ros_base/github-ros2-variants/): Built on OS Base, contains the `ros-base` variant preinstalled
+* [`desktop`](https://index.ros.org/p/desktop/github-ros2-variants/): Built on OS Base, contains the `desktop` variant preinstalled
+
+The tagging structure is `setup-ros-docker/{OS-VERSION}[-{ROS-DISTRO}-{ROS-VARIANT}]`
+
+So for example:
+* ghcr.io/ros-tooling/setup-ros-docker/ubuntu-jammy
+* ghcr.io/ros-tooling/setup-ros-docker/ubuntu-jammy-ros-humble-ros-base
+* ghcr.io/ros-tooling/setup-ros-docker/ubuntu-focal-ros-noetic-ros-desktop
+
+While this repository does provide those ROS variant-preinstalled images, its most useful output is the base OS images which are recommended for CI usage to allow for checking proper dependency specification and minimal-as-possible resulting images.
+
+Note parallel work that provides similar but different environment.
+https://github.com/osrf/docker_images also provides docker images with ROS variants already installed, but no "base development setup" images.
+
+
+## Building ARM images
+
+This repository does not yet provide ARM images for consumption, but it is perfectly easy to build them yourself for use.
+
+```
+docker build . \
+  --platform=linux/arm64 \
+  --build-arg BASE_IMAGE=ubuntu:jammy \
+  --build-arg VCS_REF=$(git rev-parse HEAD) \
+  --build-arg ROS_DISTRO=none \
+  -t ros-tooling/setup-ros-docker/ubuntu-jammy
+```


### PR DESCRIPTION
Never had a readme here, almost nobody even knew this existed or what it's for

Closes #64 

Maybe I should separate these changes? But I found that the readme should explain what's actually happening and I didn't want to document something we were to immediately remove.