### PR TITLE
Use ros2-testing repo for Jazzy before it's released

### DIFF
--- a/setup-ros.sh
+++ b/setup-ros.sh
@@ -39,6 +39,11 @@ case ${ROS_DISTRO} in
 	"noetic")
 		ROS_VERSION="ros"
 		;;
+	# Use ros2-testing repo for Jazzy before it's officially release
+	"jazzy")
+		RTI_CONNEXT_DDS="rti-connext-dds-6.0.1"
+		ROS_VERSION="ros2-testing"
+		;;
 	*)
 		RTI_CONNEXT_DDS="rti-connext-dds-6.0.1"
 		ROS_VERSION="ros2"


### PR DESCRIPTION
Follow-up to #71.

We need to use the testing apt repo to get Jazzy binaries before Jazzy is officially released. See: https://docs.ros.org/en/jazzy/Installation/Ubuntu-Install-Debians.html#enable-required-repositories. Once Jazzy has been released, we can revert this.