### PR TITLE
Prefer system packages over pip packages for Jammy

### DIFF
--- a/setup-ros.sh
+++ b/setup-ros.sh
@@ -58,8 +58,8 @@ apt-get update
 export PIP_BREAK_SYSTEM_PACKAGES=1
 UBUNTU_VERSION=$(lsb_release -cs)
 case ${UBUNTU_VERSION} in
-	"noble")
-		# For 24.04, install using apt only
+	"noble" | "jammy")
+		# For 24.04 and 22.04, install using apt only
 		# Basics
 		apt-get install --no-install-recommends --quiet --yes \
 			clang \
@@ -96,8 +96,8 @@ case ${UBUNTU_VERSION} in
 			apt-get install --no-install-recommends --quiet --yes \
 				${RTI_CONNEXT_DDS}
 		;;
-	*)
-		# For 22.04 and older, install with a mix of apt and pip
+	"focal")
+		# For 20.04, install with a mix of apt and pip
 		apt-get install --no-install-recommends --quiet --yes \
 			build-essential \
 			clang \
@@ -169,14 +169,10 @@ case ${UBUNTU_VERSION} in
 			setuptools \
 			pyparsing \
 			wheel
-		# RTI Connext
-		DEBIAN_FRONTEND=noninteractive \
-			RTI_NC_LICENSE_ACCEPTED=yes \
-			apt-get install --no-install-recommends --quiet --yes \
-				${RTI_CONNEXT_DDS}
-		# libopensplice69 does not exist on Ubuntu 20.04 and later, so we're attempting to
-		# install it, but won't fail if it does not suceed.
-		apt-get install --no-install-recommends --quiet --yes libopensplice69 || true
+		;;
+	*)
+		echo "${UBUNTU_VERSION} not supported"
+		exit 1
 		;;
 esac
 


### PR DESCRIPTION
Closes #67

Follow-up to #73 for Jammy (22.04). The list of `apt` packages is basically just the same.

----

See PR description of #73 for commands and steps to build images locally and test with `action-ros-ci`.

Testing these images over at https://github.com/ros-tooling/action-ros-ci/pull/871:

* The `Test rosdep check/skip install options` job that has been failing for a long time now works:
    * Before: https://github.com/ros-tooling/action-ros-ci/actions/runs/9130274663/job/25108392542?pr=871#step:4:6547
        * Error: `E   TypeError: import_path() missing 1 required keyword-only argument: 'consider_namespace_packages'`
    * After: https://github.com/ros-tooling/action-ros-ci/actions/runs/9133039538/job/25115696734#step:4:6328
* The `ROS 2 Docker` jobs pass and use versions of dependencies from `apt` instead of the latest ones from `pip`
    * `ROS 2 Docker (humble)`: https://github.com/ros-tooling/action-ros-ci/actions/runs/9133039538/job/25115689883
    * `ROS 2 Docker (iron)`: https://github.com/ros-tooling/action-ros-ci/actions/runs/9133039538/job/25115690442