### PR TITLE
Pin setuptools version in focal because newer version is broken against our other pins

### DIFF
--- a/.github/workflows/automerge.yml
+++ b/.github/workflows/automerge.yml
@@ -16,15 +16,14 @@ jobs:
     auto-merge-dependabot:
       runs-on: ubuntu-latest
       steps:
-        - uses: pascalgn/automerge-action@v0.12.0
+        - uses: pascalgn/automerge-action@v0.16.3
           if: github.actor == 'dependabot[bot]' || github.actor == 'dependabot-preview[bot]'
           env:
             GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
             MERGE_LABELS: "dependencies"
-            MERGE_METHOD: "squash" # Sqush and merge
+            MERGE_METHOD: "squash" # Squash and merge
             MERGE_COMMIT_MESSAGE: "pull-request-title-and-description"
             MERGE_RETRY_SLEEP: "1200000" # Retry after 20m, enough time for check suites to run
             UPDATE_RETRIES: "6"
             UPDATE_METHOD: "rebase" # Rebase PR on base branch
             UPDATE_RETRY_SLEEP: "300000"
-

--- a/Dockerfile
+++ b/Dockerfile
@@ -40,7 +40,7 @@ LABEL org.label-schema.vendor="ROS Tooling Working Group"
 
 COPY setup-ros.sh /tmp/setup-ros.sh
 RUN /tmp/setup-ros.sh "${ROS_DISTRO}" && rm -f /tmp/setup-ros.sh
-ENV LANG en_US.UTF-8
+ENV LANG=en_US.UTF-8
 RUN for i in $(echo ${EXTRA_APT_PACKAGES} | tr ',' ' '); do \
         apt-get install --yes --no-install-recommends "$i"; \
     done

--- a/setup-ros.sh
+++ b/setup-ros.sh
@@ -161,7 +161,7 @@ case ${UBUNTU_VERSION} in
 			pytest-repeat \
 			pytest-rerunfailures \
 			pytest-runner \
-			setuptools \
+			setuptools==58.2.0 \
 			pyparsing \
 			wheel
 		;;


### PR DESCRIPTION
Given our current colcon pins on focal, this happens

```
colcon_core.package_identification.python_setup_py': module 'importlib_metadata' has no attribute 'EntryPoints'
```

It's because the newest `setuptools` requires a newer version of `importlib_metadata`. We don't need to fix things for the newer version, the system version is old on Focal and that's fine, I just pin it back to a compatible version.

* While I'm changing this, update `automerge` action to pass, not sure exactly why but the old version isn't working properly anymore 🤷 
* And Docker is newer, so it doesn't like `ENV VAR VAL` now and prints a warning that you should do `ENV VAR=VAL` so I fixed that.