### PR TITLE
fix: remove libc++-* from jammy and above

### DIFF
--- a/setup-ros.sh
+++ b/setup-ros.sh
@@ -59,8 +59,6 @@ case ${UBUNTU_VERSION} in
 		apt-get install --no-install-recommends --quiet --yes \
 			clang \
 			lcov \
-			libc++-dev \
-			libc++abi-dev \
 			libssl-dev \
 			python3-dev
 		# Core, including some extra colcon packages and flake8 plugins


### PR DESCRIPTION
fixes #77  

tested on

- humble,jammy,arm64
- humble,jammy  amd64
- jazzy,noble,amd64

See https://github.com/ros-tooling/setup-ros/pull/507