### PR TITLE
Fix jammy image builds

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -24,6 +24,9 @@ jobs:
         name: Checkout repository
         uses: actions/checkout@v4
       -
+        name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+      -
         name: Set up docker buildx
         uses: docker/setup-buildx-action@v3
       -
@@ -120,6 +123,9 @@ jobs:
     -
       name: Checkout repository
       uses: actions/checkout@v4
+    -
+      name: Set up QEMU
+      uses: docker/setup-qemu-action@v3
     -
       name: Set up docker buildx
       uses: docker/setup-buildx-action@v3

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,7 +18,7 @@ jobs:
     name: "${{ matrix.base_image_name }}-${{ matrix.base_image_tag }}"
     # always use latest linux worker, as it should not have any impact
     # when it comes to building docker images.
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       -
         name: Checkout repository
@@ -118,7 +118,7 @@ jobs:
     name: "${{ matrix.output_image_tag }}"
     # always use latest linux worker, as it should not have any impact
     # when it comes to building docker images.
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
     -
       name: Checkout repository


### PR DESCRIPTION
This seems to be a QEMU error: https://github.com/ros-tooling/setup-ros-docker/actions/runs/13486261730/job/37677775532

```
 > [linux/arm64 3/5] RUN /tmp/setup-ros.sh "humble" && rm -f /tmp/setup-ros.sh:
31.58 Processing triggers for libc-bin (2.35-0ubuntu3.8) ...
31.68 qemu: uncaught target signal 11 (Segmentation fault) - core dumped
32.10 Segmentation fault (core dumped)
32.16 qemu: uncaught target signal 11 (Segmentation fault) - core dumped
32.59 Segmentation fault (core dumped)
32.59 dpkg: error processing package libc-bin (--configure):
32.59  installed libc-bin package post-installation script subprocess returned error exit status 139
32.61 Errors were encountered while processing:
32.61  libc-bin
32.73 E: Sub-process /usr/bin/dpkg returned an error code (1)
```

Not sure why. Works fine on my laptop (:tm:).